### PR TITLE
Eclipse formatting and vagrant plugin check

### DIFF
--- a/bin/solardev-workspace.sh
+++ b/bin/solardev-workspace.sh
@@ -66,6 +66,47 @@ if [ ! -e $WORKSPACE/.metadata/.plugins/org.eclipse.debug.core/.launches/SolarNe
   cp $LAUNCH_FILE $WORKSPACE/.metadata/.plugins/org.eclipse.debug.core/.launches
 fi
 
+# Install SolarNetwork code templates and formatting rules
+setProperty(){
+  # expects: property name, value, file path
+  if grep -q "^$1=" "$3"; then
+    # Update the existing property
+    awk -v pat="^$1=" -v value="`echo "$1=$2"  | sed -e 's/\\=/\\\\=/g' -e 's/\\n/\\\\n/g'`" '{ if ($0 ~ pat) print value; else print $0; }' $3 > $3.tmp
+    mv $3.tmp $3
+  else
+    # Append as a new property
+    printf "$1=$2\n" >> $3
+  fi
+}
+getXmlPropertyFromFile(){
+  # expects: file path
+  sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\\\n/g' -e 's/=/\\=/g' $1
+}
+echo -e '\nUpdating SolarNetwork Eclipse code templates and formatting rules...'
+code_templates="`getXmlPropertyFromFile $GIT_HOME/solarnetwork-build/solarnetwork-osgi-target/defs/solarnetwork-codetemplates.xml`"
+formatterprofiles="`getXmlPropertyFromFile $GIT_HOME/solarnetwork-build/solarnetwork-osgi-target/defs/solarnetwork-codeformat.xml`"
+
+setProperty "formatter_profile" "_SolarNetwork" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+setProperty "org.eclipse.jdt.ui.text.code_templates_migrated" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+setProperty "org.eclipse.jdt.ui.formatterprofiles" "$formatterprofiles" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+setProperty "org.eclipse.jdt.ui.text.custom_code_templates" "$code_templates" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+
+# Configure auto formatting on save
+setProperty "editor_save_participant_org.eclipse.jdt.ui.postsavelistener.cleanup" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+
+setProperty "sp_cleanup.format_source_code" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+setProperty "sp_cleanup.format_source_code_changes_only" "false" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+
+setProperty "sp_cleanup.organize_imports" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+
+setProperty "sp_cleanup.on_save_use_additional_actions" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+setProperty "sp_cleanup.remove_unused_imports" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+setProperty "sp_cleanup.remove_unnecessary_casts" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+setProperty "sp_cleanup.add_missing_annotations" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+setProperty "sp_cleanup.add_missing_override_annotations" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+setProperty "sp_cleanup.add_missing_override_annotations_interface_methods" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+setProperty "sp_cleanup.add_missing_deprecated_annotations" "true" "$WORKSPACE/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs"
+
 # Configure the eclipse workspace projects
 
 elementIn () {

--- a/vagrant/solarnet-dev/Vagrantfile
+++ b/vagrant/solarnet-dev/Vagrantfile
@@ -31,6 +31,12 @@ begin
     #print "No "+local_env_config_file+" found\n"
 end
 
+# Check for required plugin
+unless Vagrant.has_plugin?("vagrant-disksize")
+  puts 'vagrant-disksize plugin is required. To install run: `vagrant plugin install vagrant-disksize`'
+  abort
+end
+
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what


### PR DESCRIPTION
Adds the Eclipse code templates and formatting to the default Eclipse configuration during setup
Adds a warning to vagrant up if the vagrant-disksize plugin isn't installed